### PR TITLE
fix: concat strings without `printf`

### DIFF
--- a/actions/check-pr-title/action.yaml
+++ b/actions/check-pr-title/action.yaml
@@ -20,7 +20,7 @@ runs:
         COMMIT_MESSAGE="$PR_TITLE"
 
         if [ "${{ inputs.include_description }}" == "true" ]; then
-          COMMIT_MESSAGE=$(printf "${COMMIT_MESSAGE}\n${PR_DESCRIPTION}")
+          COMMIT_MESSAGE="${COMMIT_MESSAGE}\n${PR_DESCRIPTION}"
         fi
 
         cz check -m "$COMMIT_MESSAGE"


### PR DESCRIPTION
Using `printf` breaks the `cz check -m "$COMMIT_MESSAGE"` command, while concatentating strings seems to work properly
