### PR TITLE
feat: add `working-directory` input to `setup-pnpm` action

### DIFF
--- a/actions/setup-pnpm/action.yaml
+++ b/actions/setup-pnpm/action.yaml
@@ -12,6 +12,11 @@ inputs:
     required: false
     default: ''
 
+  working-directory:
+    description: 'The directory to run pnpm commands in'
+    required: false
+    default: '.'
+
 runs:
   using: composite
   steps:
@@ -25,7 +30,9 @@ runs:
         node-version-file: ${{ inputs.node_version_file }}
         registry-url: 'https://registry.npmjs.org'
         cache: pnpm
+        cache-dependency-path: ${{ inputs.working-directory }}/pnpm-lock.yaml
 
     - name: 'Install dependencies'
       shell: bash
       run: pnpm i --frozen-lockfile
+      working-directory: ${{ inputs.working-directory }}

--- a/actions/setup-pnpm/action.yaml
+++ b/actions/setup-pnpm/action.yaml
@@ -22,6 +22,8 @@ runs:
   steps:
     - name: 'Install pnpm'
       uses: pnpm/action-setup@v3
+      with:
+        package_json_file: ${{ inputs.working-directory }}/package.json
 
     - name: 'Install Node.js'
       uses: actions/setup-node@v4

--- a/actions/setup-pnpm/action.yaml
+++ b/actions/setup-pnpm/action.yaml
@@ -25,12 +25,22 @@ runs:
       with:
         package_json_file: ${{ inputs.working_directory }}/package.json
 
+    - name: 'Calculate node version file path'
+      shell: bash
+      id: node-version-file-path
+      # If `node_version_file` is the default `.node-version`, we need to prepend the working directory to the path
+      run: |
+        if [ "${{ inputs.node_version_file }}" = ".node-version" ]; then
+          echo "path=${{ inputs.working_directory }}/${{ inputs.node_version_file }}" >> $GITHUB_OUTPUT
+        else
+          echo "path=${{ inputs.node_version_file }}" >> $GITHUB_OUTPUT
+        fi
+
     - name: 'Install Node.js'
       uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.node_version }}
-        # If `node_version_file` is the default `.node-version`, we need to prepend the working directory to the path
-        node-version-file: ${{ inputs.node_version_file == '.node-version' && format('{0}/{1}', inputs.working_directory, inputs.node_version_file) || inputs.node_version_file }}
+        node-version-file: ${{ steps.node-version-file-path.outputs.path }}
         registry-url: 'https://registry.npmjs.org'
         cache: pnpm
         cache-dependency-path: ${{ inputs.working_directory }}/pnpm-lock.yaml

--- a/actions/setup-pnpm/action.yaml
+++ b/actions/setup-pnpm/action.yaml
@@ -38,4 +38,4 @@ runs:
     - name: 'Install dependencies'
       shell: bash
       run: pnpm i --frozen-lockfile
-      working_directory: ${{ inputs.working_directory }}
+      working-directory: ${{ inputs.working_directory }}

--- a/actions/setup-pnpm/action.yaml
+++ b/actions/setup-pnpm/action.yaml
@@ -12,7 +12,7 @@ inputs:
     required: false
     default: ''
 
-  working-directory:
+  working_directory:
     description: 'The directory to run pnpm commands in'
     required: false
     default: '.'
@@ -23,18 +23,19 @@ runs:
     - name: 'Install pnpm'
       uses: pnpm/action-setup@v3
       with:
-        package_json_file: ${{ inputs.working-directory }}/package.json
+        package_json_file: ${{ inputs.working_directory }}/package.json
 
     - name: 'Install Node.js'
       uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.node_version }}
-        node-version-file: ${{ inputs.node_version_file }}
+        # If `node_version_file` is the default `.node-version`, we need to prepend the working directory to the path
+        node-version-file: ${{ inputs.node_version_file == '.node-version' && format('{0}/{1}', inputs.working_directory, inputs.node_version_file) || inputs.node_version_file }}
         registry-url: 'https://registry.npmjs.org'
         cache: pnpm
-        cache-dependency-path: ${{ inputs.working-directory }}/pnpm-lock.yaml
+        cache-dependency-path: ${{ inputs.working_directory }}/pnpm-lock.yaml
 
     - name: 'Install dependencies'
       shell: bash
       run: pnpm i --frozen-lockfile
-      working-directory: ${{ inputs.working-directory }}
+      working_directory: ${{ inputs.working_directory }}


### PR DESCRIPTION
The need for this parameter came from https://github.com/dfinity/candid/pull/628.