### PR TITLE
feat: support `versionInTitle` input in assemble-docs action

### DIFF
--- a/actions/assemble-docs/README.md
+++ b/actions/assemble-docs/README.md
@@ -9,12 +9,13 @@ This action:
 
 ## Action inputs
 
-| Input           | Description                                                                                                                                                      | Default            |
-| --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ |
-| `assets_dir`    | Path to the directory containing the documentation assets to be assembled.                                                                                       | _required_         |
-| `version`       | The subpath at which the assembled docs will be published. Allowed values: `vX` , `vX.Y` , `vX.Y.Z` , `latest` , `beta` , `dev` , `next` , `nightly` , `canary`. | _required_         |
-| `version_label` | Optional label value to set for this version's option in the website sidebar version dropdown.                                                                   | `{inputs.version}` |
-| `target_dir`    | The folder where the assembled docs must be saved.                                                                                                               | _required_         |
+| Input              | Description                                                                                                                                                      | Default            |
+| ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ |
+| `assets_dir`       | Path to the directory containing the documentation assets to be assembled.                                                                                       | _required_         |
+| `version`          | The subpath at which the assembled docs will be published. Allowed values: `vX` , `vX.Y` , `vX.Y.Z` , `latest` , `beta` , `dev` , `next` , `nightly` , `canary`. | _required_         |
+| `version_label`    | Optional label value to set for this version's option in the website sidebar version dropdown.                                                                   | `{inputs.version}` |
+| `version_in_title` | Optional version label to show on top of the website sidebar version dropdown.                                                                                   | `''`               |
+| `target_dir`       | The folder where the assembled docs must be saved.                                                                                                               | _required_         |
 
 ## Example usage
 

--- a/actions/assemble-docs/action.yaml
+++ b/actions/assemble-docs/action.yaml
@@ -11,6 +11,9 @@ inputs:
   version_label:
     description: "Optional label value to set for this version's option in the website sidebar version dropdown. Defaults to the value of the `version` input."
     required: false
+  version_in_title:
+    description: 'Optional version label to show on top of the website sidebar version dropdown.'
+    required: false
   target_dir:
     description: 'The folder where the assembled docs must be saved.'
     required: true

--- a/actions/assemble-docs/dist/index.js
+++ b/actions/assemble-docs/dist/index.js
@@ -19190,13 +19190,18 @@ function isValidVersion(version2) {
 
 // src/upsert-versions-json.ts
 async function upsertVersionsJson(params) {
-  const { versionsJsonPath, version: version2, versionLabel } = params;
+  const { versionsJsonPath, version: version2, versionLabel, versionInTitle } = params;
   let versions = (0, import_action_utils.readJsonFile)(versionsJsonPath) || [];
   const versionEntryIndex = versions.findIndex((v) => v.path === version2);
   if (versionEntryIndex !== -1) {
     versions[versionEntryIndex].label = versionLabel;
+    if (versionInTitle) {
+      versions[versionEntryIndex].versionInTitle = versionInTitle;
+    } else {
+      delete versions[versionEntryIndex].versionInTitle;
+    }
   } else {
-    versions.push({ path: version2, label: versionLabel });
+    versions.push({ path: version2, label: versionLabel, versionInTitle });
   }
   versions = versions.sort((a, b) => {
     if (a.path === LATEST_VERSION_NAME && b.path !== LATEST_VERSION_NAME) {
@@ -19217,6 +19222,7 @@ async function run() {
     const assetsDir = (0, import_action_utils2.getInput)("assets_dir");
     const version2 = (0, import_action_utils2.getInput)("version");
     const versionLabel = (0, import_action_utils2.getOptInput)("version_label", version2);
+    const versionInTitle = (0, import_action_utils2.getOptInput)("version_in_title", "");
     const targetDir = (0, import_action_utils2.getInput)("target_dir");
     const targetZipFile = import_node_path.default.join(process.cwd(), targetDir, `${version2}.zip`);
     const targetVersionsJsonFile = import_node_path.default.join(
@@ -19241,7 +19247,8 @@ async function run() {
       await upsertVersionsJson({
         versionsJsonPath: targetVersionsJsonFile,
         version: version2,
-        versionLabel
+        versionLabel,
+        versionInTitle
       });
     }
     core.info(`Docs assembled for version ${version2}.`);

--- a/actions/assemble-docs/dist/index.js
+++ b/actions/assemble-docs/dist/index.js
@@ -19194,12 +19194,14 @@ async function upsertVersionsJson(params) {
   let versions = (0, import_action_utils.readJsonFile)(versionsJsonPath) || [];
   const versionEntryIndex = versions.findIndex((v) => v.path === version2);
   if (versionEntryIndex !== -1) {
-    versions[versionEntryIndex].label = versionLabel;
+    const versionEntry = versions[versionEntryIndex];
+    versionEntry.label = versionLabel;
     if (versionInTitle) {
-      versions[versionEntryIndex].versionInTitle = versionInTitle;
+      versionEntry.versionInTitle = versionInTitle;
     } else {
-      delete versions[versionEntryIndex].versionInTitle;
+      delete versionEntry.versionInTitle;
     }
+    versions[versionEntryIndex] = versionEntry;
   } else {
     versions.push({ path: version2, label: versionLabel, versionInTitle });
   }

--- a/actions/assemble-docs/src/main.ts
+++ b/actions/assemble-docs/src/main.ts
@@ -15,6 +15,7 @@ export async function run(): Promise<void> {
     const assetsDir = getInput('assets_dir');
     const version = getInput('version');
     const versionLabel = getOptInput('version_label', version);
+    const versionInTitle = getOptInput('version_in_title', '');
     const targetDir = getInput('target_dir');
     const targetZipFile = path.join(process.cwd(), targetDir, `${version}.zip`);
     const targetVersionsJsonFile = path.join(
@@ -44,6 +45,7 @@ export async function run(): Promise<void> {
         versionsJsonPath: targetVersionsJsonFile,
         version,
         versionLabel,
+        versionInTitle,
       });
     }
 

--- a/actions/assemble-docs/src/upsert-versions-json.ts
+++ b/actions/assemble-docs/src/upsert-versions-json.ts
@@ -15,12 +15,14 @@ export async function upsertVersionsJson(params: {
 
   const versionEntryIndex = versions.findIndex(v => v.path === version);
   if (versionEntryIndex !== -1) {
-    versions[versionEntryIndex].label = versionLabel;
+    const versionEntry = versions[versionEntryIndex];
+    versionEntry.label = versionLabel;
     if (versionInTitle) {
-      versions[versionEntryIndex].versionInTitle = versionInTitle;
+      versionEntry.versionInTitle = versionInTitle;
     } else {
-      delete versions[versionEntryIndex].versionInTitle;
+      delete versionEntry.versionInTitle;
     }
+    versions[versionEntryIndex] = versionEntry;
   } else {
     versions.push({ path: version, label: versionLabel, versionInTitle });
   }

--- a/actions/assemble-docs/src/upsert-versions-json.ts
+++ b/actions/assemble-docs/src/upsert-versions-json.ts
@@ -1,22 +1,28 @@
 import { writeJsonFile, readJsonFile } from '@dfinity/action-utils';
 import { LATEST_VERSION_NAME } from './versions';
 
-type VersionEntry = { path: string; label: string };
+type VersionEntry = { path: string; label: string; versionInTitle?: string };
 
 export async function upsertVersionsJson(params: {
   versionsJsonPath: string;
   version: string;
   versionLabel: string;
+  versionInTitle?: string;
 }): Promise<void> {
-  const { versionsJsonPath, version, versionLabel } = params;
+  const { versionsJsonPath, version, versionLabel, versionInTitle } = params;
 
   let versions = readJsonFile<VersionEntry[]>(versionsJsonPath) || [];
 
   const versionEntryIndex = versions.findIndex(v => v.path === version);
   if (versionEntryIndex !== -1) {
     versions[versionEntryIndex].label = versionLabel;
+    if (versionInTitle) {
+      versions[versionEntryIndex].versionInTitle = versionInTitle;
+    } else {
+      delete versions[versionEntryIndex].versionInTitle;
+    }
   } else {
-    versions.push({ path: version, label: versionLabel });
+    versions.push({ path: version, label: versionLabel, versionInTitle });
   }
 
   // Sort versions: latest first, then reverse alphabetically by path


### PR DESCRIPTION
Adds support for specifying `versionInTitle` parameter in the `versions.json` file
