### PR TITLE
ci!: require specifying an environment for the generate-changelog workflow

### DIFF
--- a/.github/workflows/generate-changelog.yaml
+++ b/.github/workflows/generate-changelog.yaml
@@ -53,6 +53,11 @@ on:
         required: true
         type: string
 
+      environment:
+        description: 'The name of the environment to use for the generate_changelog job.'
+        required: true
+        type: string
+
     secrets:
       token_private_key:
         description: 'A GitHub App private key used to generate an access token to create a pull request.'
@@ -60,6 +65,7 @@ on:
 jobs:
   generate_changelog:
     runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
     steps:
       - name: Create GitHub App Token
         uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6


### PR DESCRIPTION
The private keys used by the "Create GitHub App Token" step of the `generate_changelog` job are being moved into GitHub environments to enhance security. Therefor the job needs to specify this environment and the workflow needs to get the name of the environment as an input.