### PR TITLE
fix: the self-generate-changelog workflow

### DIFF
--- a/.github/workflows/self-generate-changelog.yaml
+++ b/.github/workflows/self-generate-changelog.yaml
@@ -9,10 +9,14 @@ concurrency:
   group: main-${{ github.workflow }}
   cancel-in-progress: true
 
+permissions:
+  contents: write
+
 jobs:
   generate_changelog:
     uses: ./.github/workflows/generate-changelog.yaml
     with:
       token_app_id: ${{ vars.PR_AUTOMATION_BOT_PUBLIC_APP_ID }}
+      environment: create-prs
     secrets:
       token_private_key: ${{ secrets.PR_AUTOMATION_BOT_PUBLIC_PRIVATE_KEY }}


### PR DESCRIPTION
A new `create-prs` environment has been created which defines the `PR_AUTOMATION_BOT_PUBLIC_PRIVATE_KEY` secret. This environment is only accessible from the `main` branch.

The `self-generate-changelog` workflow has been adapted to use this environment.