### PR TITLE
chore: allow specifying owner and repo for generate-changelog

### DIFF
--- a/.github/workflows/generate-changelog.yaml
+++ b/.github/workflows/generate-changelog.yaml
@@ -58,6 +58,18 @@ on:
         required: true
         type: string
 
+      owner:
+        description: 'The owner of the repository to create the pull request in.'
+        required: false
+        default: '${{ github.repository_owner }}'
+        type: string
+
+      repository:
+        description: 'The repository to create the pull request in.'
+        required: false
+        default: '${{ github.event.repository.name }}'
+        type: string
+
     secrets:
       token_private_key:
         description: 'A GitHub App private key used to generate an access token to create a pull request.'
@@ -73,6 +85,8 @@ jobs:
         with:
           app-id: ${{ inputs.token_app_id }}
           private-key: ${{ secrets.token_private_key }}
+          owner: ${{ inputs.owner }}
+          repositories: ${{ inputs.repository }}
 
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
Other repos that call the `generate-changelog` workflow need to set the `owner` and `repositories` inputs for the `actions/create-github-app-token` action. Otherwise [they fail]( 
https://github.com/dfinity/wg-web-experience/actions/runs/17578495620/job/49929179192). 

So this introduces the `owner` and `repository` inputs for the `generate-changelog` workflow and passes them to the `actions/create-github-app-token` action.