### PR TITLE
fix: use semver2 version scheme and fetch tags for pre-release compat…

### DIFF
--- a/.github/workflows/generate-changelog.yaml
+++ b/.github/workflows/generate-changelog.yaml
@@ -92,6 +92,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Setup Python
         uses: dfinity/ci-tools/actions/setup-python@main

--- a/actions/bump-version/action.yaml
+++ b/actions/bump-version/action.yaml
@@ -27,7 +27,7 @@ runs:
         PRERELEASE: ${{ inputs.prerelease }}
         MAJOR_VERSION_ZERO: ${{ inputs.major_version_zero }}
       run: |
-        cmd="cz bump --get-next --yes --version-scheme semver"
+        cmd="cz bump --get-next --yes --version-scheme semver2"
 
         if [ -n "$PRERELEASE" ]; then
           cmd="$cmd --prerelease $PRERELEASE"
@@ -46,7 +46,7 @@ runs:
         PRERELEASE: ${{ inputs.prerelease }}
         MAJOR_VERSION_ZERO: ${{ inputs.major_version_zero }}
       run: |
-        cmd="cz bump --files-only --changelog --yes --version-scheme semver"
+        cmd="cz bump --files-only --changelog --yes --version-scheme semver2"
 
         if [ -n "$PRERELEASE" ]; then
           cmd="$cmd --prerelease $PRERELEASE"

--- a/actions/generate-changelog/action.yaml
+++ b/actions/generate-changelog/action.yaml
@@ -14,4 +14,4 @@ runs:
       shell: bash
       env:
         FILE_NAME: ${{ inputs.file_name }}
-      run: cz changelog --incremental --merge-prerelease --file-name="$FILE_NAME" --version-scheme semver
+      run: cz changelog --incremental --merge-prerelease --file-name="$FILE_NAME" --version-scheme semver2

--- a/actions/generate-release-notes/action.yaml
+++ b/actions/generate-release-notes/action.yaml
@@ -20,4 +20,4 @@ runs:
       env:
         FILE_NAME: ${{ inputs.file_name }}
         VERSION: ${{ inputs.version }}
-      run: cz changelog "$VERSION" --file-name="$FILE_NAME" --version-scheme semver
+      run: cz changelog "$VERSION" --file-name="$FILE_NAME" --version-scheme semver2


### PR DESCRIPTION
## Summary
- Use `--version-scheme semver2` instead of `semver` in all commitizen actions (`bump-version`, `generate-release-notes`, `generate-changelog`)
- Add `fetch-tags: true` to the checkout step in the `generate-changelog` reusable workflow

The `semver` scheme uses Python's PEP 440 normalization, which converts `beta.0` → `b0` ([commitizen-tools/commitizen#1025](https://github.com/commitizen-tools/commitizen/issues/1025), [commitizen-tools/commitizen#150](https://github.com/commitizen-tools/commitizen/issues/150)). This causes tag mismatches — commitizen looks for `v5.2.0-b0` but the actual tag is `v5.2.0-beta.0` — resulting in `Could not find a valid revision range` errors during changelog and release notes generation.

The `semver2` scheme follows the strict semver spec and preserves pre-release identifiers as-is. No behavior change for stable releases.