### PR TITLE
fix(generate-changelog): do not fail on release commits or empty changelogs

### DIFF
--- a/.github/workflows/generate-changelog.yaml
+++ b/.github/workflows/generate-changelog.yaml
@@ -48,6 +48,12 @@ on:
         default: 'chore: generate changelog'
         type: string
 
+      release_commit_pattern:
+        description: 'Skip changelog generation when the head commit subject matches this extended regular expression. Set to an empty string to disable the check.'
+        required: false
+        default: '^chore:[[:space:]]release([[:space:]]|$)'
+        type: string
+
       token_app_id:
         description: 'A GitHub App ID used to generate an access token to create a pull request.'
         required: true
@@ -94,18 +100,40 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
+      - name: Check for release commit
+        id: release_commit
+        shell: bash
+        env:
+          RELEASE_COMMIT_PATTERN: ${{ inputs.release_commit_pattern }}
+        run: |
+          subject=$(git log -1 --format=%s)
+
+          # A release commit bumps the project version, and the matching tag is usually not
+          # pushed yet when this workflow runs. Commitizen then has nothing to changelog and
+          # exits non-zero, failing the job. Skip those commits entirely.
+          if [ -n "$RELEASE_COMMIT_PATTERN" ] && [[ "$subject" =~ $RELEASE_COMMIT_PATTERN ]]; then
+            echo 'skip=true' >> "$GITHUB_OUTPUT"
+            echo "::notice::Head commit is a release commit ('$subject'); skipping changelog generation."
+          else
+            echo 'skip=false' >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Setup Python
+        if: steps.release_commit.outputs.skip != 'true'
         uses: dfinity/ci-tools/actions/setup-python@afeee4fbdc0683a88ec5a74ed7f59a2ce0e833ad # main
 
       - name: Setup Commitizen
+        if: steps.release_commit.outputs.skip != 'true'
         uses: dfinity/ci-tools/actions/setup-commitizen@afeee4fbdc0683a88ec5a74ed7f59a2ce0e833ad # main
 
       - name: Generate changelog
+        if: steps.release_commit.outputs.skip != 'true'
         uses: dfinity/ci-tools/actions/generate-changelog@afeee4fbdc0683a88ec5a74ed7f59a2ce0e833ad # main
         with:
           file_name: ${{ inputs.file_name }}
 
       - name: Create pull request
+        if: steps.release_commit.outputs.skip != 'true'
         uses: dfinity/ci-tools/actions/create-pr@afeee4fbdc0683a88ec5a74ed7f59a2ce0e833ad # main
         with:
           branch_name: ${{ inputs.branch_name }}

--- a/actions/generate-changelog/action.yaml
+++ b/actions/generate-changelog/action.yaml
@@ -14,4 +14,17 @@ runs:
       shell: bash
       env:
         FILE_NAME: ${{ inputs.file_name }}
-      run: cz changelog --incremental --merge-prerelease --file-name="$FILE_NAME" --version-scheme semver2
+      run: |
+        set +e
+        cz changelog --incremental --merge-prerelease --file-name="$FILE_NAME" --version-scheme semver2
+        exit_code=$?
+        set -e
+
+        # Commitizen exits 3 when it finds no commits to add to the changelog. That is a
+        # no-op rather than a failure, so it must not fail the job.
+        if [ "$exit_code" -eq 3 ]; then
+          echo "::notice::No commits to add to the changelog; nothing to do."
+          exit 0
+        fi
+
+        exit "$exit_code"


### PR DESCRIPTION
Fixes #75.

`generate_changelog` fires on every push to `main`, including release-PR merges. Commitizen then has nothing to add to the changelog and exits non-zero, failing the job. Two variants have occurred in `dfinity/icp-js-core`:

| Release | Exit | Message |
|---|---|---|
| v5.4.0 | 3 | `No commits found` — as reported in #75; those logs have since expired |
| v6.0.0 | 16 | `No tag found to do an incremental changelog` ([run](https://github.com/dfinity/icp-js-core/actions/runs/28806279052)) |

Both are no-ops in intent, not errors.

I could not establish *why* one release hits 3 and the other 16. The natural theory is "tag already pushed versus not yet", but GitHub reports a release's `createdAt` as the tagged commit's date, which says nothing about when the tag was actually pushed. Both changes below are correct regardless of which fires.

## Changes

**1. Skip release commits** — new `release_commit_pattern` input, defaulting to `^chore:[[:space:]]release([[:space:]]|$)`. When the head commit subject matches, the Setup, Generate and Create-PR steps are skipped.

**2. Treat exit 3 as success** in `actions/generate-changelog`, so a release commit that slips past the subject check still does not fail the job.

Complementary rather than redundant: the subject check can miss a retitled release PR, or a repo that permits merge commits, where the subject becomes `Merge pull request #N …`.

**Exit 16 deliberately stays fatal.** Unlike 3 it is ambiguous — it also fires when tags are genuinely unavailable, for example a shallow clone or a regression in tag fetching. Swallowing it would convert a loud failure into a silent no-op, where changelog generation quietly stops working while the job stays green.

**On the default pattern:** #75 suggested `^chore:[[:space:]]release`. I require a trailing space or end-of-string, because the looser form also matches subjects like `chore: release-notes cleanup`, which would then be silently skipped. Verified against the real release subjects of all five consuming repos — note that only `icp-js-core` uses a `v` prefix, so a pattern anchored on `release v` would silently fail in the other four. Setting the input to an empty string disables the check.

## Verification

Both files parse as YAML and pass `prettier --check`. Exit handling tested under GitHub's shell (`bash --noprofile --norc -eo pipefail`) with a stub `cz`: 0 → 0, 3 → 0, 16 → 16, 1 → 1.

Not exercised against a live release — that only happens on the next release in a consuming repo.

The other half of the problem, a new branch per run causing pull requests to accumulate, is #77 and is fixed in #80. That PR touches the same workflow file; the two auto-merge cleanly, so whichever lands second only needs a rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
