### PR TITLE
fix(deps): raise brace-expansion to 5.0.9 for GHSA-rgw5-rvv9-x895

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "pnpm": {
     "overrides": {
-      "brace-expansion": "5.0.8",
+      "brace-expansion": "5.0.9",
       "undici": "^6.27.0"
     }
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  brace-expansion: 5.0.8
+  brace-expansion: 5.0.9
   undici: ^6.27.0
 
 importers:
@@ -302,8 +302,8 @@ packages:
   before-after-hook@4.0.0:
     resolution: {integrity: sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==}
 
-  brace-expansion@5.0.8:
-    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
   esbuild@0.25.12:
@@ -542,7 +542,7 @@ snapshots:
 
   before-after-hook@4.0.0: {}
 
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -589,7 +589,7 @@ snapshots:
 
   minimatch@10.2.4:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minipass@7.1.3: {}
 


### PR DESCRIPTION
[GHSA-rgw5-rvv9-x895](https://github.com/advisories/GHSA-rgw5-rvv9-x895), high severity, published today: `brace-expansion >=4.0.0 <5.0.9`, patched only in **5.0.9**.

`main` pins **5.0.8**, so `main` is affected and `audit:required` currently fails on **every open pull request** — #76, #78, #80, #81 and #82 alike. Nothing in those pull requests caused it; `pnpm audit` queries the live advisory database, so the same lockfile flipped from pass to fail with no code change.

## The policy tension, stated plainly

#79 pinned `5.0.8` **deliberately**, because `5.0.9` was four days old and inside the seven-day `minimumReleaseAge` window that `pnpm-workspace.yaml` enforces. Overrides appear to bypass that gate, so the exact pin was how the policy got respected.

That reasoning no longer holds now that 5.0.9 is the only patched version. This PR knowingly takes a package that is four days old, on the grounds that a live high-severity advisory outweighs a quarantine which 5.0.9 clears on 2026-08-06 anyway — a three-day exposure either way, and the alternative is leaving every pull request red until then.

If you would rather not breach the window, the alternatives are waiting until the 6th, or adding a `minimumReleaseAgeExclude` entry, which is a broader policy change.

## Verification

`pnpm audit` → no known vulnerabilities (was 1 high). No action bundles change, since `brace-expansion` is reached through `rimraf`, a devDependency that is not bundled into the actions. Two files only.

## Recommended merge order

1. **This PR** — clears `audit:required` on everything else.
2. **#82** — merge or close it before #80 lands. It sits on a suffixed branch that #80's `reuse_branch` behaviour will orphan. Its fate depends on whether this repo keeps a changelog at all, given it has never released: zero tags, no release workflow, and a `CHANGELOG.md` that is one permanent `Unreleased` section.
3. **#81** — collapses generated bundles in reviews. Independent of everything.
4. **#78** and **#80**, either order. Both touch `.github/workflows/generate-changelog.yaml`; they auto-merge cleanly, so the second one only needs a rebase.
5. **#76** — last. It needs someone to check the branch out and run `pnpm build`, since dependabot cannot rebuild the bundles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
